### PR TITLE
Bump evaluate to `0.3.0`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,5 +27,5 @@ streamlit-chat==0.0.2.1
 urllib3==1.26.9
 wrapt==1.14.1
 yarl==1.7.2
-evaluate==0.2.2
+evaluate==0.3.0
 discord.py==2.0.1


### PR DESCRIPTION
There is an issue with `evaluate` before 0.3.0 concerning the Hugging Face hub integration. I suggest upgrading to `0.3.0` which should not have any breaking changes and be functionally equivalent since this version might break in a few months.